### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/ev_charging/Settings.md
+++ b/docs/ev_charging/Settings.md
@@ -16,7 +16,7 @@ manage charging. There are integrations for **Tesla Wall Connectors**, **Tesla v
 **OCPP-compatible EV chargers** (e.g. **Wallbox** or **myenergi zappi**).
 
 To configure your EV charger, navigate to `Settings > Vehicle Charging`. Once the charger is configured,
-you use the `EV Charging` tab on top of the `New Automation` screen to configure automations based
+you can use the `EV Charging` tab on top of the `New Automation` screen to configure automations based
 on the start or stop of EV charging.
 
 ## Tesla Wall Connector
@@ -34,8 +34,8 @@ on the `Settings > Vehicle Charging` screen.
 
 ### Notes
 
-- If your Wall Connector is not added to your energy system, but listed as a separate product the
-  in the Tesla app (when using the top-left dropdown), you will have to contact Tesla Support to
+- If your Wall Connector is not added to your energy system, but listed as a separate product in
+  the Tesla app (when using the top-left dropdown), you will have to contact Tesla Support to
   combine the two systems into one.
 
 ## Tesla Vehicles
@@ -58,8 +58,8 @@ the state. If you had already added permissions when first logging in with Netze
 
 2. Set up a [Virtual Key](https://www.tesla.com/_ak/api.netzeroapp.io) for Netzero, a secure connection
 to your vehicle. The key can be revoked if required. Netzero does not have permission to unlock or
-start your vehicle. Note: if you are not the owner of the vehicle, you will to be in the vehicle with
-a Tesla key card when completing this process. Older Tesla Model S and X vehicle do not support
+start your vehicle. Note: if you are not the owner of the vehicle, you will need to be in the vehicle with
+a Tesla key card when completing this process. Older Tesla Model S and X vehicles do not support
 Fleet Telemetry.
 
 3. Once the key is set up, Fleet Telemetry will be automatically configured and the vehicle will
@@ -80,7 +80,7 @@ you can configure Netzero as the provider. This integration will share the EV ch
 allow remote control.
 
 Examples of compatible chargers include **Wallbox** and **myenergi zappi**. If your EV charger is compatible,
-you will see an OCPP configuration option the EV charger's app. Configure it using the following settings:
+you will see an OCPP configuration option in the EV charger's app. Configure it using the following settings:
 
 ```
 Provider: wss://ocpp.netzero.energy/

--- a/docs/subscription/NetzeroUpdate.md
+++ b/docs/subscription/NetzeroUpdate.md
@@ -87,7 +87,7 @@ will receive an in-app reminder. To avoid interruption of automations, subscribe
 New users get a **30-day free trial** and will need to subscribe to maintain access to advanced
 features.
 
-Note: the subscription is activated the moment your purchase it, and will renew after a month (or
+Note: the subscription is activated the moment you purchase it, and will renew after a month (or
 after a year for annual subscriptions).
 
 Subscriptions are available in Netzero app version 2.1.0 and above. To subscribe, go to
@@ -107,8 +107,8 @@ use the web app, you will need to log in on a mobile device once to activate the
 
 **Where are subscriptions available?**
 
-Subscriptions are currently available in United States, United Kingdom, Australia, Germany,
-New Zealand, Italy, Canada, Portugal, Netherlands, and Spain. Users in unsupported countries can
+Subscriptions are currently available in the United States, the United Kingdom, Australia, Germany,
+New Zealand, Italy, Canada, Portugal, the Netherlands, and Spain. Users in unsupported countries can
 continue using advanced features for free until support is added.
 
 Note: availability is based on your App Store / Google Play account region, which cannot be
@@ -144,7 +144,7 @@ typically due to VAT and Apple's use of fixed pricing tiers rather than current 
 **Why not offer a one-time purchase instead of a subscription?**
 
 Netzero incurs ongoing costs: cloud infrastructure costs, Tesla API charges, and development and
-support cost. For now, a subscription model better reflects these continuing expenses.
+support costs. For now, a subscription model better reflects these continuing expenses.
 
 To reduce payment frequency, consider the annual plan (16% cheaper). We may consider one-time
 purchases in the future when we get more data on subscription use.
@@ -157,7 +157,7 @@ We're big supporters of open-source development, and have contributed to the com
 unlock Powerwall 3 diagnostics access. Home Assistant is a great alternative, however not entirely
 free -- it requires time to set up and configure, some services for accessing the Tesla Fleet API
 are paid as well, it runs on a computer that needs to be powered 24/7 for automations to run, and
-cloud access to Home Assistant in an additional charge.
+cloud access to Home Assistant is an additional charge.
 
 ---
 

--- a/docs/tesla/API.md
+++ b/docs/tesla/API.md
@@ -9,7 +9,7 @@ layout: with_footer
 configuration changes using the app (backup reserve, operational mode, energy exports, and grid
 charging).
 
-For more advanced use, the app also offers an API that allows to manage these configuration changes.
+For more advanced use, the app also offers an API that allows you to manage these configuration changes.
 
 
 ## API Token

--- a/docs/tesla/BackupMode.md
+++ b/docs/tesla/BackupMode.md
@@ -22,7 +22,7 @@ this mode, the Powerwall will not discharge and will reserve 100% of its capacit
 * **Backup Mode is intended for charging only.** If your goal is simply to reserve 100% of battery
 capacity for outages, set the backup reserve to 100% in another mode instead.
 
-* The mode can be selected as an automations action (under **Set operational mode**) or from the
+* The mode can be selected as an automation action (under **Set operational mode**) or from the
   **Automation > Configuration** screen (for testing).
 
 ## How to Use Backup Mode

--- a/docs/tesla/BackupReserveUpdate.md
+++ b/docs/tesla/BackupReserveUpdate.md
@@ -6,7 +6,7 @@ layout: default
 
 ## Backup Reserve Changes
 
-On July 19 2025, Tesla changed the [Powerwall backup reserve](https://www.tesla.com/support/energy/powerwall/mobile-app/backup-reserve)
+On July 19, 2025, Tesla changed the [Powerwall backup reserve](https://www.tesla.com/support/energy/powerwall/mobile-app/backup-reserve)
 settings. Values between 81% and 99% are no longer supported. Only reserves set at 80% or below,
 or exactly 100%, remain valid.
 


### PR DESCRIPTION
## Summary
- Reworded the subscriptions update to clarify activation timing, regional availability, ongoing costs, and Home Assistant charges
- Corrected phrasing in Tesla API and Backup Mode documentation, improving clarity around API usage and automation actions
- Fixed grammar in the EV Charger Settings guide, refining setup steps and wording around Wall Connector integration and Virtual Key requirements
- Restore original phrasing around Intelligent Home Energy Management vision in subscription doc

## Testing
- `npx --yes markdownlint-cli docs/subscription/NetzeroUpdate.md docs/tesla/API.md docs/tesla/BackupMode.md docs/tesla/BackupReserveUpdate.md docs/ev_charging/Settings.md` *(fails: MD013 line-length and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898359bc63c83258ddc679e8ae4f32c